### PR TITLE
feat(front): rename area and on click state for widgets

### DIFF
--- a/backend/src/modules/area/area.controller.ts
+++ b/backend/src/modules/area/area.controller.ts
@@ -59,12 +59,13 @@ export class AreaController {
   }
 
   @Patch(':id')
-  @ApiOperation({ summary: 'Update parameters of an area by its ID' })
-  @ApiResponse({ status: 200, description: 'Area parameters updated' })
+  @ApiOperation({ summary: 'Update an area (name, or params) by its ID' })
+  @ApiResponse({ status: 200, description: 'Area updated' })
   async updateParams(
     @Param('id') id: string,
     @Body()
     dto: {
+      name?: string;
       actions?: Array<{ id: string; params?: Record<string, unknown> }>;
       reactions?: Array<{ id: string; params?: Record<string, unknown> }>;
     },

--- a/backend/src/modules/area/area.service.ts
+++ b/backend/src/modules/area/area.service.ts
@@ -496,10 +496,16 @@ export class AreaService {
   async updateParams(
     areaId: string,
     dto: {
+      name?: string;
       actions?: Array<{ id: string; params?: Record<string, unknown> }>;
       reactions?: Array<{ id: string; params?: Record<string, unknown> }>;
     },
   ) {
+    // Update name if provided
+    if (dto.name) {
+      await this.area_repository.update(areaId, { name: dto.name });
+    }
+
     if (dto.actions && dto.actions.length > 0) {
       for (const a of dto.actions) {
         const paramsJson = a.params as unknown as Prisma.InputJsonValue;

--- a/web/src/component/widget.tsx
+++ b/web/src/component/widget.tsx
@@ -49,6 +49,7 @@ export default function Widget({
     showPlatform = true,
 }: WidgetProps) {
     const [isHovered, setIsHovered] = useState(false);
+    const [isPressed, setIsPressed] = useState(false);
     const iconSrc = getPlatformIcon(platform);
     const samePlatform = !reactionPlatform || platform === reactionPlatform;
 
@@ -60,22 +61,67 @@ export default function Widget({
     const reactionHover = reactionColor
         ? lightenColor(reactionColor, 5)
         : undefined;
+
+    const primaryClicked = lightenColor(primaryColor, 20);
+    const reactionClicked = reactionColor
+        ? lightenColor(reactionColor, 20)
+        : undefined;
     const backgroundStyle =
         !reactionColor || samePlatform
-            ? { backgroundColor: isHovered ? primaryHover : primaryColor }
+            ? {
+                  backgroundColor: isPressed
+                      ? primaryClicked
+                      : isHovered
+                        ? primaryHover
+                        : primaryColor,
+              }
             : {
-                  backgroundImage: `linear-gradient(135deg, ${isHovered ? primaryHover : primaryColor} 0%, ${isHovered ? reactionHover : reactionColor} 100%)`,
+                  backgroundImage: `linear-gradient(135deg, ${isPressed ? primaryClicked : isHovered ? primaryHover : primaryColor} 0%, ${isPressed ? reactionClicked : isHovered ? reactionHover : reactionColor} 100%)`,
               };
 
     return (
         <div
-            className={`w-full sm:w-[340px] h-auto sm:h-[401px] rounded-lg shadow-md p-6 hover:shadow-lg transition-all duration-300 ease-out flex flex-col items-start justify-between shrink-0`}
+            role="button"
+            tabIndex={0}
+            aria-pressed={isPressed}
+            className={`w-full sm:w-[340px] h-auto sm:h-[401px] rounded-lg shadow-md p-6 hover:shadow-lg transition-all duration-300 ease-out flex flex-col items-start justify-between shrink-0 ${onClick ? "cursor-pointer" : ""}`}
             style={{
                 ...backgroundStyle,
             }}
-            onClick={onClick}
+            onMouseDown={() => setIsPressed(true)}
+            onMouseUp={() => {
+                if (isPressed) {
+                    setIsPressed(false);
+                    onClick?.();
+                }
+            }}
+            onTouchStart={() => setIsPressed(true)}
+            onTouchEnd={() => {
+                if (isPressed) {
+                    setIsPressed(false);
+                    onClick?.();
+                }
+            }}
+            onKeyDown={(e) => {
+                if ((e.key === "Enter" || e.key === " ") && !e.repeat) {
+                    e.preventDefault();
+                    setIsPressed(true);
+                }
+            }}
+            onKeyUp={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    if (isPressed) {
+                        setIsPressed(false);
+                        onClick?.();
+                    }
+                }
+            }}
             onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
+            onMouseLeave={() => {
+                setIsHovered(false);
+                if (isPressed) setIsPressed(false);
+            }}
         >
             <div
                 className="w-full flex-none flex items-center justify-center gap-4 mb h-64"

--- a/web/src/pages/AreaDetail.tsx
+++ b/web/src/pages/AreaDetail.tsx
@@ -1,217 +1,27 @@
-import { useState } from "react";
+import { useEffect } from "react";
 
-import { ArrowRight } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import GlassCardLayout from "@/component/glassCard";
-import Toast from "@/component/Toast";
-import { getPlatformIcon } from "@/config/platforms";
-import type { CatalogItem } from "@/data/catalogData";
-import { areaService } from "@/services/api/areaService";
-import Button from "../component/button";
-import { humanize } from "../services/aboutParser";
+import Edit from "@/component/Edit";
 
 export default function AreaDetail() {
     const location = useLocation();
     const navigate = useNavigate();
-    const { area, item } = location.state || {};
-    const [loading, setLoading] = useState(false);
-    const [showConfirm, setShowConfirm] = useState(false);
+    const { area } = location.state || {};
 
-    if (!area || !item) {
-        return (
-            <div className="flex flex-col items-center justify-center h-full">
-                <h2 className="text-2xl font-bold mb-4">Area not found</h2>
-                <Button label="Back" onClick={() => navigate("/my-areas")} />
-            </div>
-        );
-    }
-
-    const handleDelete = () => {
-        // open confirmation toast
-        setShowConfirm(true);
-    };
-
-    const confirmDelete = async () => {
-        setLoading(true);
-        try {
-            await areaService.deleteArea(area.id);
-            navigate("/my-areas");
-        } catch (err) {
-            console.error(err);
-            setLoading(false);
-        } finally {
-            setShowConfirm(false);
+    useEffect(() => {
+        if (!area) {
+            const t = setTimeout(() => navigate("/my-areas"), 0);
+            return () => clearTimeout(t);
         }
-    };
+        return undefined;
+    }, [area, navigate]);
 
-    const cancelDelete = () => {
-        setShowConfirm(false);
-    };
-
-    const renderParams = (params: Record<string, unknown>) => {
-        if (Object.keys(params).length === 0) {
-            return (
-                <p className="text-gray-400 italic text-sm mt-1">
-                    No parameters
-                </p>
-            );
-        }
-        return (
-            <div className="mt-2 rounded p-3">
-                <ul className="space-y-1">
-                    {Object.entries(params).map(([key, value]) => (
-                        <li
-                            key={key}
-                            className="text-sm text-gray-700 break-all"
-                        >
-                            <span className="font-semibold text-gray-900">
-                                {key.replace(/_/g, " ")}:
-                            </span>{" "}
-                            {String(value)}
-                        </li>
-                    ))}
-                </ul>
-            </div>
-        );
-    };
-
-    const actionName = area.actions?.[0]?.action_name || "Unknown";
-    const reactionName = area.reactions?.[0]?.reaction_name || "Unknown";
-    const actionPlatform =
-        (item && item.platform) || area.actions?.[0]?.platform;
-
-    type CatalogItemWithReaction = CatalogItem & { reactionPlatform?: string };
-    const reactionPlatform =
-        (item && (item as CatalogItemWithReaction).reactionPlatform) ||
-        area.reactions?.[0]?.platform;
-
-    const actionIcon = getPlatformIcon(actionPlatform);
-    const reactionIcon = getPlatformIcon(reactionPlatform);
-    const samePlatform = actionPlatform === reactionPlatform;
-
-    const actionParams = area.actions?.[0]?.params || {};
-    const reactionParams = area.reactions?.[0]?.params || {};
+    if (!area) return null;
 
     return (
-        <div className="relative w-full h-screen flex items-center justify-center overflow-hidden bg-slate-50">
-            <GlassCardLayout color={item.color} onBack={() => navigate(-1)}>
-                <div className="flex flex-col items-center">
-                    <span className="text-[10px] uppercase tracking-widest font-bold text-slate-400 mb-4">
-                        Resume Area
-                    </span>
-
-                    <h2 className="text-4xl text-slate-900 font-extrabold mb-10 text-center leading-tight">
-                        {item.title}
-                    </h2>
-
-                    <div className="relative mb-12">
-                        <div
-                            className="flex items-center justify-center gap-4 mb-4"
-                            role="img"
-                            aria-label={`Action ${actionPlatform}${!samePlatform ? ` and reaction ${reactionPlatform}` : ""}`}
-                        >
-                            <img
-                                src={actionIcon}
-                                alt={
-                                    actionPlatform
-                                        ? `${actionPlatform} icon`
-                                        : "action icon"
-                                }
-                                className={
-                                    samePlatform
-                                        ? "w-32 h-32 object-contain"
-                                        : "w-16 h-16 object-contain"
-                                }
-                            />
-                            {!samePlatform && (
-                                <>
-                                    <ArrowRight
-                                        className="w-6 h-6 text-gray-500"
-                                        aria-hidden
-                                    />
-                                    <img
-                                        src={reactionIcon}
-                                        alt={
-                                            reactionPlatform
-                                                ? `${reactionPlatform} icon`
-                                                : "reaction icon"
-                                        }
-                                        className="w-16 h-16 object-contain"
-                                    />
-                                </>
-                            )}
-                        </div>
-                    </div>
-                </div>
-                <div className="w-full flex flex-col items-center">
-                    <div className="w-full max-w-full space-y-6">
-                        <div
-                            className="relative pl-5 border-l-2 text-left w-full"
-                            style={{ borderColor: item.color }}
-                        >
-                            <h3 className="text-slate-400 text-[10px] font-bold uppercase tracking-wider mb-1">
-                                Action
-                            </h3>
-                            <p className="text-xl md:text-2xl font-bold text-slate-800 wrap-break-words leading-tight">
-                                {humanize(actionName)}
-                            </p>
-                            <div className="overflow-x-hidden">
-                                {renderParams(actionParams)}
-                            </div>
-                        </div>
-
-                        <div
-                            className="relative pl-5 border-l-2 text-left w-full"
-                            style={{ borderColor: item.color }}
-                        >
-                            <h3 className="text-slate-400 text-[10px] font-bold uppercase tracking-wider mb-1">
-                                Reaction
-                            </h3>
-                            <p className="text-xl md:text-2xl font-bold text-slate-800 wrap-break-words leading-tight">
-                                {humanize(reactionName)}
-                            </p>
-                            <div className="overflow-x-hidden">
-                                {renderParams(reactionParams)}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div className="w-full flex flex-wrap gap-4 justify-center mt-10">
-                        <div className="flex-1 min-w-[140px]">
-                            <Button
-                                label="Edit Area"
-                                onClick={() =>
-                                    navigate("/my-areas/edit", {
-                                        state: { area },
-                                    })
-                                }
-                                mode="black"
-                                height="small"
-                            />
-                        </div>
-                        <div className="flex-1 min-w-[140px]">
-                            <Button
-                                label={loading ? "Deleting..." : "Delete Area"}
-                                onClick={handleDelete}
-                                disabled={loading}
-                                mode="black"
-                                height="small"
-                            />
-                        </div>
-                    </div>
-                </div>
-            </GlassCardLayout>
-            <Toast
-                visible={showConfirm}
-                title={`Are you sure you want to delete "${area.name}" ?`}
-                subtitle="This action is irreversible"
-                loading={loading}
-                onConfirm={confirmDelete}
-                onCancel={cancelDelete}
-                confirmLabel={loading ? "Deletion..." : "Confirm"}
-                cancelLabel="Cancel"
-            />
+        <div className="w-full h-full">
+            <Edit area={area} />
         </div>
     );
 }

--- a/web/src/services/api/areaService.ts
+++ b/web/src/services/api/areaService.ts
@@ -28,6 +28,26 @@ class AreaService {
     async deleteArea(id: string) {
         return apiClient.delete(`${this.endpoint}/${encodeURIComponent(id)}`);
     }
+
+    async updateArea(id: string, dto: { name?: string }) {
+        return apiClient.patch(
+            `${this.endpoint}/${encodeURIComponent(id)}`,
+            dto
+        );
+    }
+
+    async updateParams(
+        id: string,
+        dto: {
+            actions?: Array<{ id: string; params?: Record<string, unknown> }>;
+            reactions?: Array<{ id: string; params?: Record<string, unknown> }>;
+        }
+    ) {
+        return apiClient.patch(
+            `${this.endpoint}/${encodeURIComponent(id)}`,
+            dto
+        );
+    }
 }
 
 export const areaService = new AreaService();


### PR DESCRIPTION
# 📦 Pull Request Summary

<!-- Provide a concise summary of your changes here. Keep it short and clear. -->
<!-- Example: "Fix issue with login flow when using 2FA" -->

---

## 📄 Type of Change

<!-- Select one or more by replacing [ ] with [x] -->

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature
- [ ] 🧹 Code Refactor
- [ ] 🔥 Hotfix
- [ ] 📚 Documentation
- [ ] 🚧 Work In Progress
- [ ] ✅ Tests Only
- [ ] 🔧 Chore (tooling, CI, infra, etc.)
- [ ] Other: <!-- specify -->

---

## 🔍 Description

<!-- Describe what this PR does and why it's needed.
     Focus on the "what" and "why", not the "how". -->

- What was the motivation for this change?
- Which problem does it solve or improve?
- Are there any side effects or potential risks?

This pull request introduces several improvements to the Area editing experience, both in the backend and frontend. The main changes include enabling the update of an area's name and parameters in a single PATCH request, enhancing the Area edit UI with a field for the area name, adding a confirmation dialog for deletion, and improving the accessibility and interactivity of the `Widget` component.

Backend enhancements:

* The Area update endpoint and service now support updating the area's name in addition to actions and reactions, allowing for more flexible edits in a single request. [[1]](diffhunk://#diff-ce2d5681811a4c6192db0cb8259dd4fb3e7b98a9df4e82cb52663b9fd9139830L62-R68) [[2]](diffhunk://#diff-a064b03146b98d0bde945901d748c93b314f521ba0fc2cb7f05b67cb758aab21R499-R508)

Frontend Area edit improvements:

* The Area edit page now includes an input field to edit the area's name, and the save logic has been updated to send only changed fields in a single PATCH request, matching the backend changes. [[1]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1R53-R76) [[2]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1L80-R135) [[3]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1R277-R294)
* Added a confirmation dialog (using `Toast`) when deleting an area, preventing accidental deletions and improving the user experience.
* Improved input field styling and label clarity for better usability and consistency. [[1]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1L129-R174) [[2]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1R186) [[3]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1L228-R268) [[4]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1L259-R311)

Accessibility and interaction improvements:

* The `Widget` component is now accessible via keyboard (supports `Enter` and `Space`), provides pressed-state feedback, and is more interactive for both mouse and touch users. [[1]](diffhunk://#diff-7841b4f0bbdfd96186ce89c43336bd10f5b3279e95bc71c847742ca3498c8d1cR52) [[2]](diffhunk://#diff-7841b4f0bbdfd96186ce89c43336bd10f5b3279e95bc71c847742ca3498c8d1cR64-R124)

Other minor improvements:

* The `formatName` utility now better formats area names by removing service prefixes.
* Type definitions for actions and reactions have been updated for consistency. [[1]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1R21-R27) [[2]](diffhunk://#diff-bd5d9e7dca1d0c82c13f3df0456f3e3aecf4a48b1bfda8a2ef9263abc9c2c4b1R38-R43)

---

## 📎 Related Issues / PRs

<!-- Link issues or other PRs here using GitHub keywords to enable automation -->

- Closes #162
- Closes #163
